### PR TITLE
Fix back-to-top button initialization timing

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -37,6 +37,9 @@ document.addEventListener('DOMContentLoaded', function() {
     
     // スクロール時のナビゲーション効果
     setupScrollEffects();
+
+    // ページの先頭に戻るボタン
+    createBackToTopButton();
 });
 
 // ==============================================
@@ -331,6 +334,3 @@ function createBackToTopButton() {
     
     document.body.appendChild(button);
 }
-
-// ページの先頭に戻るボタンを作成
-createBackToTopButton();


### PR DESCRIPTION
## Summary
- Prevent `document.body` null error by creating back-to-top button after DOM content loads

## Testing
- `node --check js/script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b92af7a45c832fbe5874ef35f0dd0c